### PR TITLE
Change newsletter subscription button label

### DIFF
--- a/packages/pliny/src/ui/NewsletterForm.tsx
+++ b/packages/pliny/src/ui/NewsletterForm.tsx
@@ -68,7 +68,7 @@ export const NewsletterForm = ({
             type="submit"
             disabled={subscribed}
           >
-            {subscribed ? 'Thank you!' : 'Sign up'}
+            {subscribed ? 'Thank you!' : 'Subscribe'}
           </button>
         </div>
       </form>


### PR DESCRIPTION
Since this is a newsletter subscription and not a website registration form, the label has been modified from "Sign up" to "Subscribe"