### PR TITLE
fix: sitemap regex

### DIFF
--- a/packages/pliny/src/utils/generate-sitemap.ts
+++ b/packages/pliny/src/utils/generate-sitemap.ts
@@ -25,7 +25,7 @@ export async function generateSitemap(siteUrl: string, allContents: MDXDocument[
                 const path = page
                   .replace('pages/', '/')
                   .replace('public/', '/')
-                  .replace(/.js|.tsx|.mdx|.md/g, '')
+                  .replace(/(\.[^\\.]+)$/, '')
                   .replace('/feed.xml', '')
                 const route = path === '/index' ? '' : path
                 return `


### PR DESCRIPTION
The current regex removes any mention of `.js|.tsx|.mdx|.md` in the file name and changes the slug when generating a sitemap.

Example: `/blog/my-new-nextjs-reactjs-portfolio.mdx` becomes `/blog/my-new-nex-reac-portfolio`