### PR TITLE
Add metadata option giscusConfig.lang to starter-blog (closes #82)

### DIFF
--- a/.changeset/thick-snails-wait.md
+++ b/.changeset/thick-snails-wait.md
@@ -1,0 +1,5 @@
+---
+"starter-blog": patch
+---
+
+Add metadata option giscusConfig.lang to starter-blog (closes #82)

--- a/starter-blog/data/siteMetadata.js
+++ b/starter-blog/data/siteMetadata.js
@@ -61,6 +61,8 @@ const siteMetadata = {
       // please provide a link below to your custom theme css file.
       // example: https://giscus.app/themes/custom_example.css
       themeURL: '',
+      // This corresponds to the `data-lang="en"` in giscus's configurations
+      lang: 'en',
     },
   },
   // search: {


### PR DESCRIPTION
Adds default Gisqus language option to starter-blog, refs #82.