### PR TITLE
Add pointer to giscus.app in starter-blog env.example

### DIFF
--- a/.changeset/proud-snails-tease.md
+++ b/.changeset/proud-snails-tease.md
@@ -1,0 +1,5 @@
+---
+"starter-blog": patch
+---
+
+Add pointer to giscus.app in starter-blog env.example

--- a/starter-blog/.env.example
+++ b/starter-blog/.env.example
@@ -1,3 +1,4 @@
+# visit https://giscus.app to get your Giscus ids
 NEXT_PUBLIC_GISCUS_REPO=
 NEXT_PUBLIC_GISCUS_REPOSITORY_ID=
 NEXT_PUBLIC_GISCUS_CATEGORY=
@@ -13,13 +14,13 @@ MAILCHIMP_AUDIENCE_ID=
 BUTTONDOWN_API_KEY=
 
 CONVERTKIT_API_KEY=
-// curl https://api.convertkit.com/v3/forms?api_key=<your_public_api_key> to get your form ID 
+# curl https://api.convertkit.com/v3/forms?api_key=<your_public_api_key> to get your form ID
 CONVERTKIT_FORM_ID=
 
 KLAVIYO_API_KEY=
 KLAVIYO_LIST_ID=
 
-REVUE_API_KEY= 
+REVUE_API_KEY=
 
 EMAILOCTOPUS_API_KEY=
 EMAILOCTOPUS_LIST_ID=


### PR DESCRIPTION
This pointer should prevent users (totally) new to Giscus having to spent time on investigating where to get these IDs.

Changed the comment tag to `.env` standard `#` symbol as a bonus.