### PR TITLE
Generic cross-env INIT_CWD for Windows and *nix

### DIFF
--- a/.changeset/olive-tigers-lick.md
+++ b/.changeset/olive-tigers-lick.md
@@ -1,0 +1,5 @@
+---
+"starter-blog": patch
+---
+
+Generic cross-env INIT_CWD for Windows and *nix

--- a/starter-blog/package.json
+++ b/starter-blog/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "next dev",
-    "dev": "INIT_CWD=$PWD next dev",
-    "build": "INIT_CWD=$PWD next build && cross-env NODE_OPTIONS='--experimental-json-modules' node -r esbuild-register ./scripts/postbuild.mjs",
+    "dev": "cross-env INIT_CWD=$PWD next dev",
+    "build": "cross-env INIT_CWD=$PWD next build && cross-env NODE_OPTIONS='--experimental-json-modules' node -r esbuild-register ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "lint": "next lint --fix --dir pages --dir components --dir lib --dir layouts --dir scripts"


### PR DESCRIPTION
Fix for currently failing `dev` and `build` commands failing on Windows with below error:

```
> starter-blog@0.0.1 dev
> INIT_CWD=$PWD next dev

'INIT_CWD' is not recognized as an internal or external command,
operable program or batch file.
```

