### PR TITLE
fix: sitemap regex

### DIFF
--- a/.changeset/cold-worms-press.md
+++ b/.changeset/cold-worms-press.md
@@ -1,0 +1,5 @@
+---
+'pliny': patch
+---
+
+fix sitemap regex

--- a/packages/pliny/src/utils/generate-sitemap.ts
+++ b/packages/pliny/src/utils/generate-sitemap.ts
@@ -25,7 +25,7 @@ export async function generateSitemap(siteUrl: string, allContents: MDXDocument[
                 const path = page
                   .replace('pages/', '/')
                   .replace('public/', '/')
-                  .replace(/.js|.tsx|.mdx|.md/g, '')
+                  .replace(/\.js|.tsx|.mdx|.md[^\/.]+$/, '')
                   .replace('/feed.xml', '')
                 const route = path === '/index' ? '' : path
                 return `


### PR DESCRIPTION
As highlighted in #83, modified regex to `/\.js|.tsx|.mdx|.md[^\/.]+$/` to only target `.js`, `.tsx`, `.mdx` and `.md` file extensions instead of globally replacing any incidence of the terms.