### PR TITLE
Add home to mobile nav drawer

### DIFF
--- a/.changeset/witty-tips-add.md
+++ b/.changeset/witty-tips-add.md
@@ -1,0 +1,5 @@
+---
+"starter-blog": patch
+---
+
+Add home to mobile nav drawer

--- a/starter-blog/components/Header.tsx
+++ b/starter-blog/components/Header.tsx
@@ -1,6 +1,6 @@
-import siteMetadata from '@/data/siteMetadata'
 import headerNavLinks from '@/data/headerNavLinks'
 import Logo from '@/data/logo.svg'
+import siteMetadata from '@/data/siteMetadata'
 import Link from './Link'
 import MobileNav from './MobileNav'
 import ThemeSwitch from './ThemeSwitch'
@@ -26,15 +26,17 @@ const Header = () => {
       </div>
       <div className="flex items-center text-base leading-5">
         <div className="hidden sm:block">
-          {headerNavLinks.map((link) => (
-            <Link
-              key={link.title}
-              href={link.href}
-              className="p-1 font-medium text-gray-900 dark:text-gray-100 sm:p-4"
-            >
-              {link.title}
-            </Link>
-          ))}
+          {headerNavLinks
+            .filter((link) => link.href !== '/')
+            .map((link) => (
+              <Link
+                key={link.title}
+                href={link.href}
+                className="p-1 font-medium text-gray-900 dark:text-gray-100 sm:p-4"
+              >
+                {link.title}
+              </Link>
+            ))}
         </div>
         <ThemeSwitch />
         <MobileNav />

--- a/starter-blog/data/headerNavLinks.ts
+++ b/starter-blog/data/headerNavLinks.ts
@@ -1,4 +1,5 @@
 const headerNavLinks = [
+  { href: '/', title: 'Home' },
   { href: '/blog', title: 'Blog' },
   { href: '/tags', title: 'Tags' },
   { href: '/projects', title: 'Projects' },


### PR DESCRIPTION
Adds `Home` link to mobile drawer navigation, skipped for desktop navigation (due to filter in `Header.tsx`).


