### PR TITLE
Update build process to work around nextjs issue

### DIFF
--- a/.changeset/dry-dolphins-burn.md
+++ b/.changeset/dry-dolphins-burn.md
@@ -1,0 +1,5 @@
+---
+'pliny': patch
+---
+
+Split all files except ui components so that they are default exported

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,6 +6,7 @@
     "pliny": "0.0.10"
   },
   "changesets": [
+    "dry-dolphins-burn",
     "fuzzy-apples-judge",
     "giant-geckos-dress",
     "good-cheetahs-tap",

--- a/packages/pliny/CHANGELOG.md
+++ b/packages/pliny/CHANGELOG.md
@@ -1,5 +1,11 @@
 # pliny
 
+## 0.1.0-beta.9
+
+### Patch Changes
+
+- e669506: Split all files except ui components so that they are default exported
+
 ## 0.1.0-beta.8
 
 ### Patch Changes

--- a/packages/pliny/add-use-client.mjs
+++ b/packages/pliny/add-use-client.mjs
@@ -15,4 +15,12 @@ import globby from 'globby'
       fs.writeFileSync(path, insert + data)
     }
   }
+  // Handle ui differently as they are not split
+  const clientPaths = await globby(['ui/NewsletterForm.js', 'ui/Pre.js'])
+  for (const path of clientPaths) {
+    console.log(path)
+    const data = fs.readFileSync(path)
+    const insert = Buffer.from('"use client"\n')
+    fs.writeFileSync(path, insert + data)
+  }
 })()

--- a/packages/pliny/package.json
+++ b/packages/pliny/package.json
@@ -2,7 +2,7 @@
   "name": "pliny",
   "description": "Main entry point for pliny components",
   "homepage": "https://github.com/timlrx/pliny",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "type": "module",
   "exports": {
     "./*": "./*",

--- a/packages/pliny/package.json
+++ b/packages/pliny/package.json
@@ -18,8 +18,8 @@
     "**"
   ],
   "scripts": {
-    "dev": "tsup-node --watch && cp -fR dist/* ./ && rimraf dist && node add-use-client.mjs && yarn copyfiles",
-    "build": "rimraf dist && tsup && cp -fR dist/* ./ && rimraf dist && node add-use-client.mjs && yarn copyfiles",
+    "dev": "tsup && cp -fR dist/* ./ && tsup --config tsup.ui.config.ts && rimraf dist && node add-use-client.mjs",
+    "build": "tsup && cp -fR dist/* ./ && tsup --config tsup.ui.config.ts && rimraf dist && node add-use-client.mjs && yarn copyfiles",
     "copyfiles": "copyfiles -f public/algolia.css search"
   },
   "author": "Timothy Lin <timothy0336@hotmail.com> (https://timlrx.com)",

--- a/packages/pliny/src/analytics/GoogleAnalytics.tsx
+++ b/packages/pliny/src/analytics/GoogleAnalytics.tsx
@@ -26,6 +26,7 @@ export const GA = ({ googleAnalyticsId }: GoogleAnalyticsProps) => {
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 export const logEvent = (action, category, label, value) => {
+  // @ts-ignore
   window.gtag?.('event', action, {
     event_category: category,
     event_label: label,

--- a/packages/pliny/src/comments/Disqus.tsx
+++ b/packages/pliny/src/comments/Disqus.tsx
@@ -15,10 +15,12 @@ export const Disqus = ({ shortname, slug }: DisqusProps) => {
   const COMMENTS_ID = 'disqus_thread'
 
   const LoadComments = useCallback(() => {
+    //@ts-ignore
     window.disqus_config = function () {
       this.page.url = window.location.href
       this.page.identifier = slug
     }
+    //@ts-ignore
     if (window.DISQUS === undefined) {
       const script = document.createElement('script')
       script.src = 'https://' + shortname + '.disqus.com/embed.js'

--- a/packages/pliny/tsup.config.ts
+++ b/packages/pliny/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/**/*'],
   format: 'esm',
+  clean: true,
   splitting: true,
   treeshake: true,
   dts: true,

--- a/packages/pliny/tsup.ui.config.ts
+++ b/packages/pliny/tsup.ui.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup'
+
+// Do not split UI files as we want to use default export
+// https://github.com/vercel/next.js/issues/52415
+export default defineConfig({
+  entry: ['src/ui/*'],
+  format: 'esm',
+  outDir: 'ui',
+  clean: true,
+  splitting: false,
+  treeshake: true,
+  dts: true,
+  silent: true,
+})


### PR DESCRIPTION
For UI components that needs to be imported by mdx components, they should be default exported to avoid running into this issue: https://github.com/vercel/next.js/issues/52415.

As such, we need two separate build scripts to handle the default case with splitting and appending "use client" to chunks as well as the above case.