### PR TITLE
Enhance and fix kbar

### DIFF
--- a/.changeset/large-geckos-allow.md
+++ b/.changeset/large-geckos-allow.md
@@ -1,0 +1,5 @@
+---
+'pliny': patch
+---
+
+upgrade kbar version

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,5 +5,8 @@
     "@pliny/config": "0.0.0",
     "pliny": "0.1.1"
   },
-  "changesets": []
+  "changesets": [
+    "large-geckos-allow",
+    "soft-humans-scream"
+  ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@pliny/config": "0.0.0",
+    "pliny": "0.1.1"
+  },
+  "changesets": []
+}

--- a/.changeset/soft-humans-scream.md
+++ b/.changeset/soft-humans-scream.md
@@ -1,0 +1,5 @@
+---
+'pliny': patch
+---
+
+Expose onSearchDocumentsLoad for kbar and allow searchDocumentsPath to be false

--- a/packages/pliny/CHANGELOG.md
+++ b/packages/pliny/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pliny
 
+## 0.1.2-beta.0
+
+### Patch Changes
+
+- a19ed9f: upgrade kbar version
+- 79ed1c1: Expose onSearchDocumentsLoad for kbar and allow searchDocumentsPath to be false
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/pliny/package.json
+++ b/packages/pliny/package.json
@@ -2,7 +2,7 @@
   "name": "pliny",
   "description": "Main entry point for pliny components",
   "homepage": "https://github.com/timlrx/pliny",
-  "version": "0.1.1",
+  "version": "0.1.2-beta.0",
   "type": "module",
   "exports": {
     "./*": "./*",

--- a/packages/pliny/package.json
+++ b/packages/pliny/package.json
@@ -32,7 +32,7 @@
     "github-slugger": "^1.4.0",
     "image-size": "1.0.0",
     "js-yaml": "4.1.0",
-    "kbar": "0.1.0-beta.41",
+    "kbar": "0.1.0-beta.43",
     "next-contentlayer": "^0.3.4",
     "next-themes": "^0.2.1",
     "remark": "^14.0.2",

--- a/packages/pliny/src/search/KBar.tsx
+++ b/packages/pliny/src/search/KBar.tsx
@@ -3,12 +3,14 @@ import type { Action } from 'kbar'
 import { KBarProvider } from 'kbar'
 import { useRouter } from 'next/navigation.js'
 import { KBarModal } from './KBarModal'
-import { CoreContent, MDXDocument } from '../utils/contentlayer'
-import { formatDate } from '../utils/formatDate'
+import { CoreContent, MDXDocument } from 'pliny/utils/contentlayer'
+import { formatDate } from 'pliny/utils/formatDate'
 
 export interface KBarSearchProps {
-  searchDocumentsPath: string
+  searchDocumentsPath: string | false
   defaultActions?: Action[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSearchDocumentsLoad?: (json: any) => Action[]
 }
 
 export interface KBarConfig {
@@ -18,6 +20,11 @@ export interface KBarConfig {
 
 /**
  * Command palette like search component with kbar - `ctrl-k` to open the palette.
+ *
+ * Default actions can be overridden by passing in an array of actions to `defaultActions`.
+ * To load actions dynamically, pass in a `searchDocumentsPath` to a JSON file.
+ * `onSearchDocumentsLoad` can be used to transform the JSON into actions.
+ *
  * To toggle the modal or search from child components, use the search context:
  * ```
  * import { useKBar } from 'kbar'
@@ -33,24 +40,13 @@ export const KBarSearchProvider: FC<{
   kbarConfig: KBarSearchProps
 }> = ({ kbarConfig, children }) => {
   const router = useRouter()
-  const { searchDocumentsPath, defaultActions } = kbarConfig
+  const { searchDocumentsPath, defaultActions, onSearchDocumentsLoad } = kbarConfig
   const [searchActions, setSearchActions] = useState<Action[]>([])
   const [dataLoaded, setDataLoaded] = useState(false)
 
   useEffect(() => {
     const mapPosts = (posts: CoreContent<MDXDocument>[]) => {
-      const startingActions = Array.isArray(defaultActions)
-        ? defaultActions
-        : [
-            {
-              id: 'homepage',
-              name: 'Homepage',
-              keywords: '',
-              section: 'Home',
-              perform: () => router.push('/'),
-            },
-          ]
-      const actions: Action[] = startingActions
+      const actions: Action[] = []
       for (const post of posts) {
         actions.push({
           id: post.path,
@@ -64,20 +60,24 @@ export const KBarSearchProvider: FC<{
       return actions
     }
     async function fetchData() {
-      const url =
-        searchDocumentsPath.indexOf('://') > 0 || searchDocumentsPath.indexOf('//') === 0
-          ? searchDocumentsPath
-          : new URL(searchDocumentsPath, window.location.origin)
-      const res = await fetch(url)
-      const json = await res.json()
-      const actions = mapPosts(json)
-      setSearchActions(actions)
+      if (searchDocumentsPath) {
+        const url =
+          searchDocumentsPath.indexOf('://') > 0 || searchDocumentsPath.indexOf('//') === 0
+            ? searchDocumentsPath
+            : new URL(searchDocumentsPath, window.location.origin)
+        const res = await fetch(url)
+        const json = await res.json()
+        const actions = onSearchDocumentsLoad ? onSearchDocumentsLoad(json) : mapPosts(json)
+        setSearchActions(actions)
+        setDataLoaded(true)
+      }
+    }
+    if (!dataLoaded && searchDocumentsPath) {
+      fetchData()
+    } else {
       setDataLoaded(true)
     }
-    if (!dataLoaded) {
-      fetchData()
-    }
-  }, [defaultActions, dataLoaded, router, searchDocumentsPath])
+  }, [defaultActions, dataLoaded, router, searchDocumentsPath, onSearchDocumentsLoad])
 
   return (
     <KBarProvider actions={defaultActions}>

--- a/packages/pliny/src/search/KBar.tsx
+++ b/packages/pliny/src/search/KBar.tsx
@@ -3,8 +3,8 @@ import type { Action } from 'kbar'
 import { KBarProvider } from 'kbar'
 import { useRouter } from 'next/navigation.js'
 import { KBarModal } from './KBarModal'
-import { CoreContent, MDXDocument } from 'pliny/utils/contentlayer'
-import { formatDate } from 'pliny/utils/formatDate'
+import { CoreContent, MDXDocument } from '../utils/contentlayer'
+import { formatDate } from '../utils/formatDate'
 
 export interface KBarSearchProps {
   searchDocumentsPath: string | false

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,13 +3235,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"command-score@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "command-score@npm:0.1.2"
-  checksum: b733fd552d7e569070da3d474b1ed5f54785fdf3dd61670002e0a00b2eff1a547c2b6d3af3683c012f4f39c6455f9e7ee5e9997a79c08048ec37ec2195d3df08
-  languageName: node
-  linkType: hard
-
 "commander@npm:^4.0.0":
   version: 4.1.1
   resolution: "commander@npm:4.1.1"
@@ -4680,6 +4673,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: 17ae758ce205276ebd88bd9c9f088a100be0b4896abac9f6b09847151269d1690f41d7f98ff5813d4a58973162dbd99d0072ce807020fee6f9de60170f6b08eb
+  languageName: node
+  linkType: hard
+
 "gauge@npm:^4.0.3":
   version: 4.0.4
   resolution: "gauge@npm:4.0.4"
@@ -5804,19 +5804,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kbar@npm:0.1.0-beta.41":
-  version: 0.1.0-beta.41
-  resolution: "kbar@npm:0.1.0-beta.41"
+"kbar@npm:0.1.0-beta.43":
+  version: 0.1.0-beta.43
+  resolution: "kbar@npm:0.1.0-beta.43"
   dependencies:
     "@radix-ui/react-portal": ^1.0.1
-    command-score: ^0.1.2
     fast-equals: ^2.0.3
+    fuse.js: ^6.6.2
     react-virtual: ^2.8.2
     tiny-invariant: ^1.2.0
   peerDependencies:
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 4ce40d59c27b0a9367fbface0780f906c20109bc279b038041e51b0f97fee50261599fda8cfc5ba8e45550589639517f580935ec6443e835081057d9bb5a6e54
+  checksum: cb3eee56295cd6697149ca083ae42957dccbc15cc52b9fbe62b4ebb6e7e3613a812ed8a0083e81be7aadcb85e22d007a59ac5cee25e0a0caa4ba4c95bb5606c8
   languageName: node
   linkType: hard
 
@@ -7691,7 +7691,7 @@ __metadata:
     github-slugger: ^1.4.0
     image-size: 1.0.0
     js-yaml: 4.1.0
-    kbar: 0.1.0-beta.41
+    kbar: 0.1.0-beta.43
     next: 13.4.10
     next-contentlayer: ^0.3.4
     next-themes: ^0.2.1


### PR DESCRIPTION
## Change Log
- Upgrade kbar version to 0.1.0-beta.43 which uses fuse search
- Expose `onSearchDocumentsLoad` which overrides the default `mapPosts`, closes #130 
- Allow `searchDocumentsPath` to be `false`. If so, fetch would not be triggered and kbar would just consists of the default actions.