### PR TITLE
Fix transforming internal urls to relative urls from algolia

### DIFF
--- a/.changeset/chilled-jokes-fold.md
+++ b/.changeset/chilled-jokes-fold.md
@@ -1,0 +1,5 @@
+---
+'pliny': minor
+---
+
+Fix converting internal domains to relative paths in the Algolia Search component.

--- a/packages/pliny/src/search/Algolia.tsx
+++ b/packages/pliny/src/search/Algolia.tsx
@@ -125,11 +125,11 @@ export const AlgoliaSearchProvider: React.FC<React.PropsWithChildren<AlgoliaSear
 
   const transformItems = useRef<DocSearchModalProps['transformItems']>((items) =>
     items.map((item) => {
-      // If Algolia contains a external domain, we should navigate without
-      // relative URL
+      // Assuming all entries indexed in algolia are internal domains
+
       const isInternalLink = item.url.startsWith('/')
       const isAnchorLink = item.url.startsWith('#')
-      if (!isInternalLink && !isAnchorLink) {
+      if (isInternalLink || isAnchorLink) {
         return item
       }
 


### PR DESCRIPTION
This fixes: https://github.com/timlrx/pliny/issues/158

You should return the item if it's an anchor or an internal link.

When it's not either of those, it is a valid url where you can transform the url and strip the hostname.

This could be extended by having a way to differentiate internal and external domains, maybe passing down `siteMetadata.siteUrl` to this component.