### PR TITLE
Updated URL of `beehiiv` API endpoint

### DIFF
--- a/packages/pliny/src/newsletter/beehiiv.ts
+++ b/packages/pliny/src/newsletter/beehiiv.ts
@@ -1,11 +1,11 @@
 export const beehiivSubscribe = async (email: string) => {
   const API_KEY = process.env.BEEHIIV_API_KEY
   const PUBLICATION_ID = process.env.BEEHIIV_PUBLICATION_ID
-  const API_URL = 'https://api.beehiiv.com/v2'
+  const API_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`
+
 
   const data = {
     email,
-    publication_id: PUBLICATION_ID,
     reactivate_existing: false,
     send_welcome_email: true,
   }

--- a/packages/pliny/src/newsletter/beehiiv.ts
+++ b/packages/pliny/src/newsletter/beehiiv.ts
@@ -3,14 +3,13 @@ export const beehiivSubscribe = async (email: string) => {
   const PUBLICATION_ID = process.env.BEEHIIV_PUBLICATION_ID
   const API_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`
 
-
   const data = {
     email,
     reactivate_existing: false,
     send_welcome_email: true,
   }
 
-  const response = await fetch(`${API_URL}/subscribers`, {
+  const response = await fetch(API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
I think URL that is being used in `beehiiv` newsletter is wrong. 
Current documentation from `beehiiv`: [docs](https://developers.beehiiv.com/docs/v2/1a77a563675ee-create)