### PR TITLE
Add support for custom host URL in Umami component and dynamic data attributes (#184)

### DIFF
--- a/packages/pliny/src/analytics/Umami.tsx
+++ b/packages/pliny/src/analytics/Umami.tsx
@@ -1,8 +1,8 @@
 import Script from 'next/script.js'
 
 export interface UmamiProps {
-  umamiWebsiteId: string
   src?: string
+  umamiWebsiteId: string
 }
 
 export const Umami = ({
@@ -13,8 +13,8 @@ export const Umami = ({
     <Script
       async
       defer
-      data-website-id={umamiWebsiteId}
       src={src} // Replace with your umami instance
+      data-website-id={umamiWebsiteId}
     />
   )
 }


### PR DESCRIPTION
This PR addresses Issue #184 by providing a workaround for users facing ad-blocker issues with the default Umami script URL (https://analytics.umami.is/script.js, or https://cloud.umami.is/script.js). When hosting the Umami script on a custom/own site domain, users can now specify the data-host-url attribute to direct analytics data to the appropriate endpoint (e.g., https://cloud.umami.is), bypassing ad-blockers like those in Brave.

Changes:
Custom Host URL Support: Adds a data-host-url attribute, allowing users to set a custom host when they self-host the Umami script. This provides a way to work around ad-blocking issues.
Other Umami attributes: Beside optional umamiHostUrl (data-host-url), it adds other optional attributes as umamiTag (data-tag), umamiAutoTrack (data-auto-track), umamiExcludeSearch (data-exclude-search), umamiDomains (data-domains). 
Dynamic Data Attributes: Extends support for arbitrary data-* attributes, allowing users to specify any existing or future Umami options directly on the component without additional code changes (e.g., dataNewOption would add data-new-option, while xyzNewOption would add nothing since all umami attributes starts with the data- prefix).
Context:
These changes allow users to host the Umami script on their own domains, bypassing ad-blockers that block the default Umami URL. Additionally, the component now dynamically accepts any data-* attributes, future-proofing it for potential updates to Umami's configuration options.

