### PR TITLE
Add support for custom host URL in Umami component and dynamic data attributes

### DIFF
--- a/packages/pliny/src/analytics/Umami.tsx
+++ b/packages/pliny/src/analytics/Umami.tsx
@@ -1,20 +1,61 @@
-import Script from 'next/script.js'
+import Script from 'next/script'
 
+/**
+ * Props for the Umami component.
+ */
 export interface UmamiProps {
+  /** The unique Umami website ID. */
   umamiWebsiteId: string
+  /** The Umami host URL. */
+  umamiHostUrl?: string
+  /** Tag to identify the script. */
+  umamiTag?: string
+  /** Enable or disable automatic tracking. Defaults to true. */
+  umamiAutoTrack?: boolean
+  /** Exclude URL query parameters from tracking. Defaults to false. */
+  umamiExcludeSearch?: boolean
+  /** A comma-separated list of domains to limit tracking to. */
+  umamiDomains?: string
+  /** Source URL for the Umami script. Defaults to the official CDN. */
   src?: string
+  /** Additional data attributes for the script tag. */
+  [key: `data${string}`]: any
 }
 
-export const Umami = ({
-  umamiWebsiteId,
-  src = 'https://analytics.umami.is/script.js',
-}: UmamiProps) => {
-  return (
-    <Script
-      async
-      defer
-      data-website-id={umamiWebsiteId}
-      src={src} // Replace with your umami instance
-    />
-  )
+const propToDataAttributeMap: { [key: string]: string } = {
+  umamiWebsiteId: 'data-website-id',
+  umamiHostUrl: 'data-host-url',
+  umamiTag: 'data-tag',
+  umamiAutoTrack: 'data-auto-track',
+  umamiExcludeSearch: 'data-exclude-search',
+  umamiDomains: 'data-domains',
+}
+
+/**
+ * A React component that integrates Umami analytics via a script tag.
+ *
+ * @param props - The props for the Umami component.
+ * @returns A Script element with the Umami analytics script and dynamic data attributes.
+ */
+export const Umami = ({ src = 'https://analytics.umami.is/script.js', ...props }: UmamiProps) => {
+  const dataAttributes: Record<string, any> = {}
+
+  // Map known Umami props to data attributes
+  Object.entries(propToDataAttributeMap).forEach(([propName, dataAttrName]) => {
+    const value = props[propName as keyof UmamiProps]
+    if (value !== undefined) {
+      dataAttributes[dataAttrName] = typeof value === 'boolean' ? String(value) : value
+    }
+  })
+
+  // Include additional data attributes passed via props
+  Object.entries(props).forEach(([key, value]) => {
+    if (key.startsWith('data') && value !== undefined && !(key in propToDataAttributeMap)) {
+      // Convert camelCase to kebab-case for HTML attributes
+      const attributeName = key.replace(/([A-Z])/g, '-$1').toLowerCase()
+      dataAttributes[attributeName] = value
+    }
+  })
+
+  return <Script async defer src={src} {...dataAttributes} />
 }


### PR DESCRIPTION
This PR addresses Issue https://github.com/timlrx/pliny/issues/184 by providing a workaround for users facing ad-blocker issues with the default Umami script URL (https://analytics.umami.is/script.js, or https://cloud.umami.is/script.js). When hosting the Umami script on a custom/own site domain, users can now specify the data-host-url attribute to direct analytics data to the appropriate endpoint (e.g., https://cloud.umami.is/), bypassing ad-blockers like those in Brave.

### Changes:
- **Custom Host URL Support**: Adds a data-host-url attribute, allowing users to set a custom host when they self-host the Umami script. This provides a way to work around ad-blocking issues.
- **Other Umami attributes**: Beside optional umamiHostUrl (data-host-url), it adds other optional attributes as umamiTag (data-tag), umamiAutoTrack (data-auto-track), umamiExcludeSearch (data-exclude-search), umamiDomains (data-domains).
- **Dynamic Data Attributes**: Extends support for arbitrary data-* attributes, allowing users to specify any existing or future Umami options directly on the component without additional code changes (e.g., dataNewOption would add data-new-option, while xyzNewOption would add nothing since all umami attributes starts with the data- prefix).
### Context:
These changes allow users to host the Umami script on their own domains, bypassing ad-blockers that block the default Umami URL. Additionally, the component now dynamically accepts any data-* attributes, future-proofing it for potential updates to Umami's configuration options.