### PR TITLE
feat: add indentDepth prop to TOCInline component

### DIFF
--- a/packages/pliny/src/ui/TOCInline.tsx
+++ b/packages/pliny/src/ui/TOCInline.tsx
@@ -2,6 +2,7 @@ import { Toc, TocItem } from '../mdx-plugins/remark-toc-headings'
 
 export interface TOCInlineProps {
   toc: Toc
+  indentDepth?: number
   fromHeading?: number
   toHeading?: number
   asDisclosure?: boolean
@@ -52,6 +53,7 @@ const createNestedList = (items: TocItem[]): NestedTocItem[] => {
  * If you are using tailwind css and want to revert to the default HTML list style, set `ulClassName="[&_ul]:list-[revert]"`
  * @param {TOCInlineProps} {
  *   toc,
+ *   indentDepth = 3,
  *   fromHeading = 1,
  *   toHeading = 6,
  *   asDisclosure = false,
@@ -64,6 +66,7 @@ const createNestedList = (items: TocItem[]): NestedTocItem[] => {
  */
 const TOCInline = ({
   toc,
+  indentDepth = 3,
   fromHeading = 1,
   toHeading = 6,
   asDisclosure = false,
@@ -89,7 +92,7 @@ const TOCInline = ({
     return (
       <ul className={ulClassName}>
         {items.map((item, index) => (
-          <li key={index} className={liClassName}>
+          <li key={index} className={liClassName + `${item.depth >= indentDepth ? ' ml-6' : ''}`}>
             <a href={item.url}>{item.value}</a>
             {createList(item.children)}
           </li>

--- a/packages/pliny/src/ui/TOCInline.tsx
+++ b/packages/pliny/src/ui/TOCInline.tsx
@@ -92,7 +92,13 @@ const TOCInline = ({
     return (
       <ul className={ulClassName}>
         {items.map((item, index) => (
-          <li key={index} className={liClassName + `${item.depth >= indentDepth ? ' ml-6' : ''}`}>
+          <li
+            key={index}
+            className={
+              liClassName +
+              `${item.depth >= indentDepth && item.depth > fromHeading + 1 ? ' ml-6' : ''}`
+            }
+          >
             <a href={item.url}>{item.value}</a>
             {createList(item.children)}
           </li>


### PR DESCRIPTION
The [new features in v1 blog post](https://timlrx.github.io/tailwind-nextjs-starter-blog/blog/new-features-in-v1#table-of-contents-component) for the tailwind-nextjs-starter-blog repo says

>  By default, all headings that are of depth 3 or smaller are indented. This can be configured by changing the indentDepth property.

But this property and feature doesn't exist in the package.

I couldn't run any tests or anything to check if this worked (none available in the repo), but I think this works 🤞